### PR TITLE
Update vqmod.php

### DIFF
--- a/vqmod/vqmod.php
+++ b/vqmod/vqmod.php
@@ -117,7 +117,7 @@ abstract class VQMod {
 			return $sourceFile;
 		}
 
-		$stripped_filename = preg_replace('~^' . preg_quote(self::getCwd(), '~i') . '~', '', $sourcePath);
+		$stripped_filename = preg_replace('~^' . preg_quote(self::getCwd(), '~') . '~i', '', $sourcePath);
 		$cacheFile = self::_cacheName($stripped_filename);
 		$file_last_modified = filemtime($sourcePath);
 


### PR DESCRIPTION
Fixes issue that made vQmod unable to write to the cache under IIS8.

Tested on IIS8, PHP 5.5.33, OpenCart 1.5.2.1 (I know), vQmod 2.5.1.

## Symptoms
vQmod fails to save modifications to /vqmod/vqcache/vq2-*.php

Instead it writes an empty file named _vq-2-C_

## Cause
Error in the value generated for $stripped_filename. May relate to the way PHP's realpath() behaves on IIS.

## Resolution

Make _preg_replace_ case insensitive by changing
`$stripped_filename = preg_replace('~^' . preg_quote(self::getCwd(), '~i') . '~', '', $sourcePath);`

To
`$stripped_filename = preg_replace('~^' . preg_quote(self::getCwd(), '~') . '~i', '', $sourcePath);`

`i` on the original _preg_quote_ is not required.