### PR TITLE
Remove duplicate lines

### DIFF
--- a/vqmod/vqmod.php
+++ b/vqmod/vqmod.php
@@ -149,6 +149,9 @@ abstract class VQMod {
 			}
 		} else {
 			file_put_contents(self::path(self::$checkedCache, true), $stripped_filename . PHP_EOL, FILE_APPEND | LOCK_EX);
+			$lines = file(self::path(self::$checkedCache, true));
+			$lines = array_unique($lines);
+			file_put_contents(self::path(self::$checkedCache, true), implode($lines));
 			self::$_doNotMod[] = $sourcePath;
 		}
 


### PR DESCRIPTION
It solves a problem for me, which loaded the same routes, repeating lines every time I accessed the website where vQmod is installed, generating an unnecessarily very long and heavy checked.cache file.

PD: I had tested it on 11-06-19.