### PR TITLE
Uncontrollable checked.cache file when the storage directory resides outside of document root

### DIFF
--- a/vqmod/vqmod.php
+++ b/vqmod/vqmod.php
@@ -336,7 +336,7 @@ abstract class VQMod {
 			$paths = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 			if(!empty($paths)) {
 				foreach($paths as $path) {
-					$fullPath = self::path($path, true);
+					$fullPath = preg_match('%^([a-z]:)?[\\\\/]%i', $path) ? $path : self::path($path, true);
 					if($fullPath) {
 						self::$_doNotMod[] = $fullPath;
 					}


### PR DESCRIPTION
As of OC 3.x, it is recommended to move the storage directory outside of the document root. When the storage directory is moved outside of the document root, `self::$_cwd` is failed to replace the current working directory from the file-path as a result, native ocmoded files are being inserted as the absolute path in `checked.cache` whereas vqmod expects the relative path only. As a consequence, the `checked.cache` grows sizes uncontrollably and make the site slow.

One solution could be to consider the absolute path in `checked.cache` as well. This patch will consider the absolute path along with the existing relative path when it fetches checked files in `_loadChecked()`
