### PR TITLE
Update vqmod.php

### DIFF
--- a/vqmod/vqmod.php
+++ b/vqmod/vqmod.php
@@ -548,7 +548,7 @@ class VQModLog {
 	 * @return null
 	 * @description Adds error to log object ready to be output
 	 */
-	public function write($data, VQModObject $obj = NULL) {
+	public function write($data, ?VQModObject $obj = NULL) {
 		if($obj) {
 			$hash = sha1($obj->id);
 		} else {


### PR DESCRIPTION
PHP 8.4 fix 
Implicitly marking parameter $obj as nullable is deprecated, the explicit nullable type must be used instead